### PR TITLE
[hotfix]: Remove remnant references to /asset directory

### DIFF
--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 

--- a/src/components/App.test.tsx
+++ b/src/components/App.test.tsx
@@ -1,16 +1,53 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen, waitForElementToBeRemoved } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
 import App from './App';
 
-test('renders', async () => {
-    const { getAllByText } = render(
+test('Initial render is on the homepage', async () => {
+    const { getByLabelText } = render(
         <MemoryRouter>
             <App />
         </MemoryRouter>,
     );
-    const homeTextElements = getAllByText('d.jin');
-    expect(homeTextElements.length).toEqual(2);
-    homeTextElements.forEach((element) => expect(element).toBeInTheDocument());
+    const homePageTitle = getByLabelText('Home Page Title');
+    const homePageDescription = getByLabelText('Home Page Description');
+    expect(homePageTitle).not.toBeNull();
+    expect(homePageDescription).not.toBeNull();
+});
+
+describe('Navigation Drawer Open/Close State Management', () => {
+    const OPEN_DRAWER_BTN_LABEL = 'Open Drawer Button';
+    const CLOSE_DRAWER_BTN_LABEL = 'Close Drawer Button';
+
+    test('Can open the navigation drawer', async () => {
+        const { getByLabelText, findByLabelText, queryByLabelText } = render(
+            <MemoryRouter>
+                <App />
+            </MemoryRouter>,
+        );
+        const openDrawerButton = getByLabelText(OPEN_DRAWER_BTN_LABEL);
+        fireEvent.click(openDrawerButton); // Open the drawer
+        const closeDrawerButton = await findByLabelText(CLOSE_DRAWER_BTN_LABEL);
+        expect(closeDrawerButton).not.toBeNull();
+        const openDrawerButtonAfterOpening = queryByLabelText(OPEN_DRAWER_BTN_LABEL);
+        expect(openDrawerButtonAfterOpening).toBeNull();
+    });
+
+    test('Can close the navigation drawer', async () => {
+        const { getByLabelText, findByLabelText, queryByLabelText } = render(
+            <MemoryRouter>
+                <App />
+            </MemoryRouter>,
+        );
+        const openDrawerButton = getByLabelText(OPEN_DRAWER_BTN_LABEL);
+
+        fireEvent.click(openDrawerButton); // Open the drawer
+        const closeDrawerButton = await findByLabelText(CLOSE_DRAWER_BTN_LABEL);
+        fireEvent.click(closeDrawerButton); // Close the drawer
+        const openDrawerButtonAfterClosing = await findByLabelText(OPEN_DRAWER_BTN_LABEL);
+        const closeDrawerButtonAfterClosing = queryByLabelText(CLOSE_DRAWER_BTN_LABEL);
+        expect(openDrawerButtonAfterClosing).not.toBeNull();
+        expect(closeDrawerButtonAfterClosing).toBeNull();
+    });
 });

--- a/src/components/AppContent/HomePage/HomePage.styles.ts
+++ b/src/components/AppContent/HomePage/HomePage.styles.ts
@@ -1,6 +1,5 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
-import aboutBg from 'assets/about/media/about_bg.jpg';
 
 const homePageStyles = makeStyles((theme: Theme) =>
     createStyles({
@@ -20,9 +19,6 @@ const homePageStyles = makeStyles((theme: Theme) =>
         },
         contrastText: {
             color: theme.palette.primary.contrastText,
-        },
-        bg: {
-            backgroundImage: `url(${aboutBg})`,
         },
     }),
 );

--- a/src/components/AppContent/HomePage/HomePage.tsx
+++ b/src/components/AppContent/HomePage/HomePage.tsx
@@ -16,10 +16,15 @@ const HomePage: React.FC = () => {
         <Background imageUrl={aboutBg} className={classes.center}>
             <Grow in>
                 <div className={classes.pageContent}>
-                    <Typography variant={isSmall ? 'h3' : 'h1'} align="center">
+                    <Typography variant={isSmall ? 'h3' : 'h1'} align="center" aria-label="Home Page Title">
                         d.jin
                     </Typography>
-                    <Typography paragraph variant={isSmall ? 'body1' : 'h6'} align="center">
+                    <Typography
+                        paragraph
+                        variant={isSmall ? 'body1' : 'h6'}
+                        align="center"
+                        aria-label="Home Page Description"
+                    >
                         d.jin is a coder, music producer, DJ, and martial artist hailing from the sun-soaked shores of
                         SoCal.
                     </Typography>

--- a/src/components/AppContent/MartialArtsPage/MartialArtsPage.styles.ts
+++ b/src/components/AppContent/MartialArtsPage/MartialArtsPage.styles.ts
@@ -1,6 +1,5 @@
 import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
 import { fade } from '@material-ui/core/styles/colorManipulator';
-import studioBg from 'assets/martialArts/media/studio_bg.png';
 
 const martialArtsPageStyles = makeStyles((theme: Theme) =>
     createStyles({

--- a/src/components/AppContent/MusicScoresPage/MusicScoresPage.styles.ts
+++ b/src/components/AppContent/MusicScoresPage/MusicScoresPage.styles.ts
@@ -1,5 +1,4 @@
 import { createStyles, makeStyles } from '@material-ui/core/styles';
-import musicScoreBg from 'assets/music/media/music_score_bg.jpeg';
 
 const musicScoresPageStyles = makeStyles(() =>
     createStyles({
@@ -7,7 +6,6 @@ const musicScoresPageStyles = makeStyles(() =>
             padding: 20,
         },
         bg: {
-            backgroundImage: `url(${musicScoreBg})`,
             paddingBottom: 10,
             width: '100vw',
         },

--- a/src/components/AppContent/ReclaimerPage/ReclaimerPage.styles.ts
+++ b/src/components/AppContent/ReclaimerPage/ReclaimerPage.styles.ts
@@ -1,5 +1,4 @@
 import { createStyles, makeStyles } from '@material-ui/core/styles';
-import reclaimerBg from 'assets/reclaimer/media/reclaimer_bg.png';
 
 const reclaimerPageStyles = makeStyles(() =>
     createStyles({

--- a/src/components/AppDrawer/AppDrawer.tsx
+++ b/src/components/AppDrawer/AppDrawer.tsx
@@ -44,9 +44,11 @@ const AppDrawer: React.FC<AppDrawerProps> = ({ closeAppDrawer, isAppDrawerOpen }
             }}
         >
             <div className={classes.header}>
-                <IconButton onClick={closeAppDrawer} data-testid="close-drawer-btn">
-                    {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
-                </IconButton>
+                {isAppDrawerOpen && (
+                    <IconButton onClick={closeAppDrawer} aria-label={'Close Drawer Button'}>
+                        {theme.direction === 'ltr' ? <ChevronLeftIcon /> : <ChevronRightIcon />}
+                    </IconButton>
+                )}
             </div>
             <Divider />
             <List>

--- a/src/components/AppToolbar/AppToolbar.styles.ts
+++ b/src/components/AppToolbar/AppToolbar.styles.ts
@@ -20,9 +20,6 @@ const appToolbarStyles = makeStyles((theme: Theme) =>
                 duration: theme.transitions.duration.enteringScreen,
             }),
         },
-        hide: {
-            display: 'none',
-        },
         homeLink: {
             color: '#fff',
             textDecoration: 'none',

--- a/src/components/AppToolbar/AppToolbar.tsx
+++ b/src/components/AppToolbar/AppToolbar.tsx
@@ -17,15 +17,17 @@ const AppToolbar: React.FC<AppToolbarProps> = ({ isAppDrawerOpen, openAppDrawer 
     return (
         <AppBar position="fixed" className={clsx(classes.root, isAppDrawerOpen && classes.shift)}>
             <Toolbar>
-                <IconButton
-                    color="inherit"
-                    aria-label="open drawer"
-                    onClick={openAppDrawer}
-                    edge="start"
-                    className={clsx(classes.menuButton, isAppDrawerOpen && classes.hide)}
-                >
-                    <MenuIcon />
-                </IconButton>
+                {!isAppDrawerOpen && (
+                    <IconButton
+                        color="inherit"
+                        aria-label="Open Drawer Button"
+                        onClick={openAppDrawer}
+                        edge="start"
+                        className={classes.menuButton}
+                    >
+                        <MenuIcon />
+                    </IconButton>
+                )}
                 <Link to="/" className={classes.homeLink}>
                     <img src={logo} alt="d.jin website logo" className={classes.logo} />
                     <Typography variant="h6" noWrap>

--- a/src/components/shared/Background/Background.tsx
+++ b/src/components/shared/Background/Background.tsx
@@ -22,7 +22,6 @@ const Background: React.FC<BackgroundProps> = ({
     const classes = backgroundStyles();
     const theme = useTheme();
     const tintOpacity = tint ? 0.5 : 0;
-    console.log(tintOpacity);
     return (
         <div className={classes.bg} style={{ backgroundImage: `url(${imageUrl})`, backgroundColor: color }}>
             <div

--- a/src/data/education.ts
+++ b/src/data/education.ts
@@ -1,7 +1,3 @@
-import pblaLogo from 'assets/education/logo/pbla.jpg';
-import ucsdLogo from 'assets/education/logo/ucsd.png';
-import uscLogo from 'assets/education/logo/usc.png';
-import yonseiLogo from 'assets/education/logo/yonsei.png';
 import { Education, EduType } from 'types/education';
 
 import { PBLA, UCSD, USC, Yonsei } from '../const/semester';

--- a/src/data/research.ts
+++ b/src/data/research.ts
@@ -1,5 +1,3 @@
-import costBenefitAnalysisImg from 'assets/research/media/cost_benefit_analysis.jpg';
-import linkageToCareImg from 'assets/research/media/linkage_to_care.jpg';
 import { Research } from 'types/research';
 
 import { UCSD } from '../const/semester';


### PR DESCRIPTION
Remnant references to `/asset` were not caught on `react-scripts` rerenders. Had to use `eslint` to spot them. Also wrote the first few unit tests to check open/close drawer state management.