### PR TITLE
[bug]: Fix navigation bugs

### DIFF
--- a/src/api/firestore/useCollection.ts
+++ b/src/api/firestore/useCollection.ts
@@ -26,19 +26,23 @@ export default function useCollection<T extends DocumentData>(
 ): SWRResponse<FirestoreDocument<T>[], Error> {
     const { query: queryConstraints = [], parseDates = [] } = options || {};
     const { db } = useContext(FirebaseContext);
-    return useSWR(isNotNil(db) ? `${collectionId}` : null, async (cName): Promise<FirestoreDocument<T>[]> => {
-        // This condition should never be triggered since useSWR doesn't start the request until the DB is initialized
-        if (!db) {
-            return [];
-        }
-        const fsCollection: QuerySnapshot =
-            queryConstraints.length > 0
-                ? await getDocs(query(collection(db, cName), ...queryConstraints))
-                : await getDocs(collection(db, cName));
-        return fsCollection.docs
-            .filter((doc) => doc.exists())
-            .map((doc) =>
-                parseDocumentDates(toFirestoneDocument(doc as unknown as QueryDocumentSnapshot<T>), parseDates),
-            );
-    });
+    return useSWR(
+        isNotNil(db) ? `${collectionId}_${JSON.stringify(queryConstraints)}_${JSON.stringify(parseDates)}` : null,
+        async (key): Promise<FirestoreDocument<T>[]> => {
+            // This condition should never be triggered since useSWR doesn't start the request until the DB is initialized
+            if (!db) {
+                throw new Error('Firestore DB has not been initialized yet.');
+            }
+            const cName = key.split('_')[0];
+            const fsCollection: QuerySnapshot =
+                queryConstraints.length > 0
+                    ? await getDocs(query(collection(db, cName), ...queryConstraints))
+                    : await getDocs(collection(db, cName));
+            return fsCollection.docs
+                .filter((doc) => doc.exists())
+                .map((doc) =>
+                    parseDocumentDates(toFirestoneDocument(doc as unknown as QueryDocumentSnapshot<T>), parseDates),
+                );
+        },
+    );
 }

--- a/src/components/shared/ResponsiveGrid/ResponsiveGrid.tsx
+++ b/src/components/shared/ResponsiveGrid/ResponsiveGrid.tsx
@@ -7,7 +7,7 @@ import Embed from 'react-embed';
 
 import responsiveGridStyles from './ResponsiveGrid.styles';
 
-const COL_HEIGHT = 333;
+const ROW_HEIGHT = 333;
 
 interface ResponsiveGridProps<T> {
     title?: string;
@@ -32,7 +32,7 @@ function ResponsiveGrid<T>({
     const titleVariant = isMedium ? 'h4' : isSmall ? 'h5' : 'h6';
     return (
         <div className={clsx(classes.root, className)}>
-            <ImageList cellHeight={COL_HEIGHT} cols={cols} spacing={10}>
+            <ImageList rowHeight={ROW_HEIGHT} cols={cols} gap={10}>
                 {title && (
                     <ImageListItem cols={cols} style={{ height: 'auto' }}>
                         <Typography paragraph variant={titleVariant} align="center" className={classes.gridHeader}>


### PR DESCRIPTION
Previously, when navigating between different pages using the same Firestore collection (e.g. `music/education` vs `coding/education`), the content of the page would not change. The queries were changing, but they were not added to the cache key that `useSWR` caches.  Fixed the caching mechanism to account for different queries.